### PR TITLE
Automatically set CCACHE_EXEC to the system's ccache

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1889,6 +1889,19 @@ validate_current_shell
 source_vendorsetup
 addcompletions
 
+# check and set ccache path on envsetup
+if [ -z ${CCACHE_EXEC} ]; then
+    ccache_path=$(which ccache)
+    if [ ! -z "$ccache_path" ]; then
+        export USE_CCACHE=1
+        export CCACHE_COMPRESS=1
+        export CCACHE_EXEC="$ccache_path"
+        echo -e "\e[1mccache enabled and \e[32m\e[4mCCACHE_EXEC\e[0m \e[1mhas been set to : \e[4m$ccache_path\e[0m"
+    else
+        echo -e "\e[31m\e[1mccache not found/installed!\e[0m"
+    fi
+fi
+
 export ANDROID_BUILD_TOP=$(gettop)
 
 . $ANDROID_BUILD_TOP/vendor/ssos/build/envsetup.sh


### PR DESCRIPTION
* Check for ccache tool and set its path in CCACHE_EXEC if it hasn't been set already

* Enable ccache and compression by default

Change-Id: Ife9d0a723cb90b89392ee288ebe6e7e9f2be7eef