### PR TITLE
combo: Add cortex-a76 to known v8-2a cores

### DIFF
--- a/core/combo/TARGET_linux-arm.mk
+++ b/core/combo/TARGET_linux-arm.mk
@@ -33,7 +33,7 @@
 KNOWN_ARMv8_CORES := cortex-a53 cortex-a53.a57 cortex-a55 cortex-a73 cortex-a75 cortex-a76
 KNOWN_ARMv8_CORES += kryo kryo385 exynos-m1 exynos-m2
 
-KNOWN_ARMv82a_CORES := cortex-a55 cortex-a75 kryo385
+KNOWN_ARMv82a_CORES := cortex-a55 cortex-a75 cortex-a76 kryo385
 
 ifeq (,$(strip $(TARGET_$(combo_2nd_arch_prefix)CPU_VARIANT)))
   TARGET_$(combo_2nd_arch_prefix)CPU_VARIANT := generic


### PR DESCRIPTION
Allow building a76 with TARGET_2ND_ARCH_VARIANT set as armv8-2a

Change-Id: I620aa16d6cc563687d35916fc0cd56fb08f9ca71
Signed-off-by: Jason Edson <jaysonedson@gmail.com>
Signed-off-by: Akash <akashniki@gmail.com>